### PR TITLE
modify the function init_centroids:

### DIFF
--- a/tools/k_means_yolo.py
+++ b/tools/k_means_yolo.py
@@ -66,7 +66,7 @@ def init_centroids(boxes,n_anchors):
     boxes_num = len(boxes)
 
     centroid_index = np.random.choice(boxes_num, 1)
-    centroids.append(boxes[centroid_index])
+    centroids.append(boxes[centroid_index[0]])
 
     print(centroids[0].w,centroids[0].h)
 


### PR DESCRIPTION
use plus =1, the error occurs: centroids.append(boxes[centroid_index])  TypeError: only integer scalar arrays can be converted to a scalar index